### PR TITLE
Add automatic owner setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM n8nio/n8n
+
+COPY entrypoint.sh /entrypoint.sh
+COPY create-user.js /create-user.js
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ This repository contains a simple Docker Compose setup for running [n8n](https:/
 2. Clone this repository and run:
 
 ```bash
-docker compose up -d
+docker compose up -d --build
 ```
 
 The compose file exposes n8n on port `5678`. A volume is created for the n8n data so your workflows persist across container restarts.
+On first start, if no user exists, an owner account will be created automatically
+using the credentials from the environment variables `N8N_DEFAULT_EMAIL` and
+`N8N_DEFAULT_PASSWORD` (see `docker-compose.yml`). You can also configure the
+name of the initial user with `N8N_DEFAULT_FIRSTNAME` and
+`N8N_DEFAULT_LASTNAME`.
 
 The PostgreSQL service uses the `pgvector/pgvector` image and initializes the `vector` extension on first start using the script in `postgres/init-vector.sql`.
 

--- a/create-user.js
+++ b/create-user.js
@@ -1,0 +1,38 @@
+const http = require('http');
+
+const email = process.env.N8N_DEFAULT_EMAIL || 'admin@example.com';
+const password = process.env.N8N_DEFAULT_PASSWORD || 'changeme';
+const firstName = process.env.N8N_DEFAULT_FIRSTNAME || 'Owner';
+const lastName = process.env.N8N_DEFAULT_LASTNAME || 'User';
+
+const data = JSON.stringify({ email, password, firstName, lastName });
+
+function setup() {
+  const req = http.request({
+    hostname: 'localhost',
+    port: 5678,
+    path: '/rest/owner/setup',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data),
+    },
+  }, res => {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      console.log('Owner account created');
+    } else if (res.statusCode === 400 || res.statusCode === 409) {
+      console.log('Owner already exists');
+    } else {
+      console.log(`Unexpected response: ${res.statusCode}`);
+    }
+  });
+
+  req.on('error', err => {
+    console.error('Setup request failed:', err.message);
+  });
+
+  req.write(data);
+  req.end();
+}
+
+setup();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - mongodb_data:/data/db
 
   n8n:
-    image: n8nio/n8n
+    build: .
     restart: unless-stopped
     ports:
       - "5678:5678"
@@ -33,6 +33,10 @@ services:
       DB_POSTGRESDB_PASSWORD: n8n
       EXECUTIONS_PROCESS: main
       N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN: "true"
+      N8N_DEFAULT_EMAIL: admin@example.com
+      N8N_DEFAULT_PASSWORD: changeme
+      N8N_DEFAULT_FIRSTNAME: Owner
+      N8N_DEFAULT_LASTNAME: User
     depends_on:
       - postgres
       - mongodb

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Start n8n in background
+n8n start &
+N8N_PID=$!
+
+# Wait until n8n is reachable
+until curl -sf http://localhost:5678/ > /dev/null; do
+  echo "Waiting for n8n to start..."
+  sleep 2
+done
+
+# Attempt owner setup if no user exists
+node /create-user.js || true
+
+# Wait for n8n to exit
+wait $N8N_PID


### PR DESCRIPTION
## Summary
- build a custom n8n image
- add an entrypoint script and Node helper to create a default owner user when none exists
- document automatic user creation and add default user env vars

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683dfd79695c8333bad47f66869caed0