### PR TITLE
Add pdf-toolkit container

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MongoDB is started with a default user of `root` and password `example`. Adjust 
 - **n8n**: Low-code workflow automation tool.
 - **PostgreSQL**: Database for n8n configured with the `pgvector` extension.
 - **MongoDB**: Additional database which can be used by custom workflows.
+- **PDF Toolkit**: Tools for processing PDF files.
 
 ## Volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     volumes:
       - mongodb_data:/data/db
 
+  pdf-toolkit:
+    image: pdf-toolkit
+    restart: unless-stopped
+
   n8n:
     build: .
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add `pdf-toolkit` service in `docker-compose.yml`
- list PDF Toolkit in the README services section

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e104050048333be25b83618ed1563