### PR TITLE
Replace pdf-toolkit service with Stirling-PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MongoDB is started with a default user of `root` and password `example`. Adjust 
 - **n8n**: Low-code workflow automation tool.
 - **PostgreSQL**: Database for n8n configured with the `pgvector` extension.
 - **MongoDB**: Additional database which can be used by custom workflows.
-- **PDF Toolkit**: Tools for processing PDF files.
+- **Stirling-PDF**: Tools for processing PDF files.
 
 ## Volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,11 @@ services:
     volumes:
       - mongodb_data:/data/db
 
-  pdf-toolkit:
-    image: pdf-toolkit
+  stirling-pdf:
+    image: ghcr.io/stirling-pdf/stirling-pdf:latest
     restart: unless-stopped
+    ports:
+      - "8080:8080"
 
   n8n:
     build: .


### PR DESCRIPTION
## Summary
- use Stirling-PDF container in docker-compose
- document Stirling-PDF as a service

## Testing
- `bash -n entrypoint.sh` *(fails: bash not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e162075ec83339f5b373abd1cb175