### PR TITLE
Fix base package manager detection for curl install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM n8nio/n8n
 
 # Install curl used by the custom entrypoint
-RUN apt-get update \
-    && apt-get install -y curl \
-    && rm -rf /var/lib/apt/lists/*
+USER root
+RUN if command -v apt-get >/dev/null; then \
+        apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*; \
+    elif command -v apk >/dev/null; then \
+        apk add --no-cache curl; \
+    else \
+        echo "No supported package manager found" && exit 1; \
+    fi
+USER node
 
 COPY entrypoint.sh /entrypoint.sh
 COPY create-user.js /create-user.js


### PR DESCRIPTION
## Summary
- detect package manager when installing curl
- elevate privileges with `USER root` before installing packages

## Testing
- ❌ `docker image build .` (fails: `docker: command not found`)

`This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_b_683ebfb120e48333bfdec5ed9b3d820f