### PR TITLE
Add Adminer service for Postgres management

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ The PostgreSQL service uses the `pgvector/pgvector` image and initializes the `v
 
 MongoDB is started with a default user of `root` and password `example`. Adjust the credentials in `docker-compose.yml` as needed.
 
+Adminer is exposed on port `8081` and allows managing the PostgreSQL database through a browser.
+
 ## Services
 
 - **n8n**: Low-code workflow automation tool.
 - **PostgreSQL**: Database for n8n configured with the `pgvector` extension.
 - **MongoDB**: Additional database which can be used by custom workflows.
 - **Stirling-PDF**: Tools for processing PDF files.
+- **Adminer**: Browser-based interface for PostgreSQL management.
 
 ## Volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,12 @@ services:
     ports:
       - "8080:8080"
 
+  adminer:
+    image: adminer
+    restart: unless-stopped
+    ports:
+      - "8081:8080"
+
   n8n:
     build: .
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- expose Adminer container on port 8081 in `docker-compose.yml`
- document the Adminer service and port in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683ec116f1e8833381e4b0cf00e0b76c