### PR TITLE
Add service endpoints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Adminer is exposed on port `8081` and allows managing the PostgreSQL database th
 - **Stirling-PDF**: Tools for processing PDF files.
 - **Adminer**: Browser-based interface for PostgreSQL management.
 
+## Endpoints
+
+- **n8n UI**: <http://localhost:5678>
+- **n8n REST API**: <http://localhost:5678/rest>
+- **Stirling-PDF**: <http://localhost:8080>
+- **Adminer**: <http://localhost:8081>
+- **PostgreSQL**: `postgres://n8n:n8n@localhost:5432/n8n`
+- **MongoDB**: `mongodb://root:example@mongodb:27017` (internal only)
+
+
 ## Volumes
 
 - `n8n_data` – stores n8n configuration and workflows


### PR DESCRIPTION
## Summary
- document links for the web services and databases

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68400708c05c83338962aa0debd7f80e